### PR TITLE
Implement HttpClient singleton for consistent session handling

### DIFF
--- a/HttpClient.py
+++ b/HttpClient.py
@@ -1,0 +1,33 @@
+import requests
+
+class HttpClient:
+    def __init__(self):
+        self.session = requests.Session()
+
+    def __del__(self):
+        self.session.close()
+
+    def post(self, url: str, headers: dict = None, data: dict = None) -> requests.Response:
+        session_headers = self.session.headers.copy()
+        if headers:
+            session_headers.update(headers)
+        res = self.session.post(url, headers=session_headers, data=data, timeout=10, allow_redirects=True)
+        res.raise_for_status()
+        return res
+
+    def get(self, url: str, headers: dict = None, params: dict = None) -> requests.Response:
+        session_headers = self.session.headers.copy()
+        if headers:
+            session_headers.update(headers)
+        res = self.session.get(url, headers=session_headers, params=params, timeout=10)
+        res.raise_for_status()
+        return res
+
+class HttpClientSingleton:
+    _instance = None
+
+    @staticmethod
+    def get_instance():
+        if HttpClientSingleton._instance is None:
+            HttpClientSingleton._instance = HttpClient()
+        return HttpClientSingleton._instance

--- a/auth.py
+++ b/auth.py
@@ -1,6 +1,6 @@
 import copy
 import requests
-
+from HttpClient import HttpClientSingleton
 
 class AuthController:
     _REQ_HEADERS = {
@@ -22,6 +22,10 @@ class AuthController:
     }
 
     _AUTH_CRED = ""
+
+
+    def __init__(self):
+        self.http_client = HttpClientSingleton.get_instance()
 
     def login(self, user_id: str, password: str):
         assert type(user_id) == str
@@ -47,7 +51,7 @@ class AuthController:
         return copied_headers
 
     def _get_default_auth_cred(self):
-        res = requests.get(
+        res = self.http_client.get(
             "https://dhlottery.co.kr/gameResult.do?method=byWin&wiselog=H_C_1_1"
         )
 
@@ -85,7 +89,7 @@ class AuthController:
         assert type(headers) == dict
         assert type(data) == dict
 
-        res = requests.post(
+        res = self.http_client.post(
             "https://www.dhlottery.co.kr/userSsl.do?method=login",
             headers=headers,
             data=data,

--- a/controller.py
+++ b/controller.py
@@ -6,6 +6,7 @@ import auth
 import lotto645
 import win720
 import notification
+import time
 
 
 def buy_lotto645(authCtrl: auth.AuthController, cnt: int, mode: str):
@@ -55,9 +56,12 @@ def check():
 
     globalAuthCtrl = auth.AuthController()
     globalAuthCtrl.login(username, password)
+    
     response = check_winning_lotto645(globalAuthCtrl)
     send_message(0, 0, response=response, webhook_url=discord_webhook_url)
 
+    time.sleep(10)
+    
     response = check_winning_win720(globalAuthCtrl)
     send_message(0, 1, response=response, webhook_url=discord_webhook_url)
 
@@ -78,7 +82,9 @@ def buy():
     response = buy_lotto645(globalAuthCtrl, count, mode) 
     send_message(1, 0, response=response, webhook_url=discord_webhook_url)
 
-    response = buy_win720(globalAuthCtrl, username) 
+    time.sleep(10)
+    
+    response = buy_win720(globalAuthCtrl, username)
     send_message(1, 1, response=response, webhook_url=discord_webhook_url)
 
 def run():

--- a/controller.py
+++ b/controller.py
@@ -20,9 +20,9 @@ def check_winning_lotto645(authCtrl: auth.AuthController) -> dict:
     item = lotto.check_winning(authCtrl)
     return item
 
-def buy_win720(authCtrl: auth.AuthController):
+def buy_win720(authCtrl: auth.AuthController, username: str):
     pension = win720.Win720()
-    response = pension.buy_Win720(authCtrl)
+    response = pension.buy_Win720(authCtrl, username)
     response['balance'] = pension.get_balance(auth_ctrl=authCtrl)
     return response
 
@@ -78,7 +78,7 @@ def buy():
     response = buy_lotto645(globalAuthCtrl, count, mode) 
     send_message(1, 0, response=response, webhook_url=discord_webhook_url)
 
-    response = buy_win720(globalAuthCtrl) 
+    response = buy_win720(globalAuthCtrl, username) 
     send_message(1, 1, response=response, webhook_url=discord_webhook_url)
 
 def run():

--- a/lotto645.py
+++ b/lotto645.py
@@ -1,12 +1,12 @@
-import json
 import datetime
-import requests
-
-from enum import Enum
-from bs4 import BeautifulSoup as BS
+import json
 from datetime import timedelta
+from enum import Enum
+
+from bs4 import BeautifulSoup as BS
 
 import auth
+from HttpClient import HttpClientSingleton
 
 class Lotto645Mode(Enum):
     AUTO = 1
@@ -15,6 +15,7 @@ class Lotto645Mode(Enum):
     CHECK = 20
 
 class Lotto645:
+
     _REQ_HEADERS = {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36",
         "Connection": "keep-alive",
@@ -32,6 +33,9 @@ class Lotto645:
         "Sec-Fetch-Dest": "document",
         "Accept-Language": "ko,en-US;q=0.9,en;q=0.8,ko-KR;q=0.7",
     }
+
+    def __init__(self):
+        self.http_client = HttpClientSingleton.get_instance()
 
     def buy_lotto645(
         self, 
@@ -94,14 +98,15 @@ class Lotto645:
         raise NotImplementedError()
 
     def _getRequirements(self, headers: dict) -> list: 
-        org_headers = headers
+        org_headers = headers.copy()
 
         headers["Referer"] ="https://ol.dhlottery.co.kr/olotto/game/game645.do"
         headers["Content-Type"] = "application/json; charset=UTF-8"
         headers["X-Requested-With"] ="XMLHttpRequest"
 
+
 		#no param needed at now
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://ol.dhlottery.co.kr/olotto/game/egovUserReadySocket.json", 
             headers=headers
         )
@@ -109,7 +114,7 @@ class Lotto645:
         direct = json.loads(res.text)["ready_ip"]
         
 
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://ol.dhlottery.co.kr/olotto/game/game645.do", 
             headers=org_headers
         )
@@ -123,7 +128,7 @@ class Lotto645:
         return [direct, draw_date, tlmt_date]
 
     def _get_round(self) -> str:
-        res = requests.get("https://www.dhlottery.co.kr/common.do?method=main")
+        res = self.http_client.get("https://www.dhlottery.co.kr/common.do?method=main")
         html = res.text
         soup = BS(
             html, "html5lib"
@@ -134,7 +139,7 @@ class Lotto645:
     def get_balance(self, auth_ctrl: auth.AuthController) -> str: 
 
         headers = self._generate_req_headers(auth_ctrl)
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://dhlottery.co.kr/userSsl.do?method=myPage", 
             headers=headers
         )
@@ -152,7 +157,7 @@ class Lotto645:
 
         headers["Content-Type"]  = "application/x-www-form-urlencoded; charset=UTF-8"
 
-        res = requests.post(
+        res = self.http_client.post(
             "https://ol.dhlottery.co.kr/olotto/game/execBuy.do",
             headers=headers,
             data=data,
@@ -176,31 +181,33 @@ class Lotto645:
             "sortOrder": "DESC"
         }
 
-        res = requests.post(
-            "https://dhlottery.co.kr/myPage.do?method=lottoBuyList",
-            headers=headers,
-            data=data
-        )
-
-        html = res.text
-        soup = BS(html, "html5lib")
-        
-        winnings = soup.find("table", class_="tbl_data tbl_data_col").find_all("tbody")[0].find_all("td")        
-
         result_data = {
             "data": "no winning data"
         }
-        
-        if len(winnings) == 1:
-            return result_data
-            
 
-        result_data = {
-            "round": winnings[2].text.strip(),
-            "money": winnings[6].text.strip(),
-            "purchased_date": winnings[0].text.strip(),
-            "winning_date": winnings[7].text.strip()
-        }
+        try:
+            res = self.http_client.post(
+                "https://dhlottery.co.kr/myPage.do?method=lottoBuyList",
+                headers=headers,
+                data=data
+            )
+
+            html = res.text
+            soup = BS(html, "html5lib")
+
+            winnings = soup.find("table", class_="tbl_data tbl_data_col").find_all("tbody")[0].find_all("td")
+
+            if len(winnings) == 1:
+                return result_data
+
+            result_data = {
+                "round": winnings[2].text.strip(),
+                "money": winnings[6].text.strip(),
+                "purchased_date": winnings[0].text.strip(),
+                "winning_date": winnings[7].text.strip()
+            }
+        except:
+            pass
 
         return result_data
     

--- a/notification.py
+++ b/notification.py
@@ -1,8 +1,6 @@
 import requests
 
-                    
-class Notification: 
-
+class Notification:
     def send_lotto_buying_message(self, body: dict, webhook_url: str) -> None:
         assert type(webhook_url) == str
 
@@ -29,7 +27,6 @@ class Notification:
         return lotto_number
 
     def send_win720_buying_message(self, body: dict, webhook_url: str) -> None:
-        assert type(webhook_url) == str
         
         if body.get("resultCode") != '100':  
             return       
@@ -38,6 +35,7 @@ class Notification:
 
         win720_number_str = self.make_win720_number_message(body.get("saleTicket"))
         message = f"{win720_round}회 연금복권 구매 완료 :moneybag: 남은잔액 : {body['balance']}\n```\n{win720_number_str}```"
+        self._send_discord_webhook(webhook_url, message)
 
     def make_win720_number_message(self, win720_number: str) -> str:
         return "\n".join(win720_number.split(","))

--- a/notification.py
+++ b/notification.py
@@ -37,7 +37,7 @@ class Notification:
         win720_round = body.get("resultMsg").split("|")[3]
 
         win720_number_str = self.make_win720_number_message(body.get("saleTicket"))
-        message = f"{win720_round}회 연금복권 구매 완료 :moneybag: 남은잔액 : {body['balance']}\n```{win720_number_str}```"
+        message = f"{win720_round}회 연금복권 구매 완료 :moneybag: 남은잔액 : {body['balance']}\n```\n{win720_number_str}```"
 
     def make_win720_number_message(self, win720_number: str) -> str:
         return "\n".join(win720_number.split(","))

--- a/win720.py
+++ b/win720.py
@@ -44,7 +44,8 @@ class Win720:
 
     def buy_Win720(
         self, 
-        auth_ctrl: auth.AuthController, 
+        auth_ctrl: auth.AuthController,
+        username: str
     ) -> dict:
         assert type(auth_ctrl) == auth.AuthController
 
@@ -58,7 +59,7 @@ class Win720:
         extracted_num = json.loads(parsed_ret)["selLotNo"]
         orderNo, orderDate = self._doOrderRequest(auth_ctrl, win720_round, extracted_num)
         
-        body = json.loads(self._doConnPro(auth_ctrl, win720_round, extracted_num, orderNo, orderDate))
+        body = json.loads(self._doConnPro(auth_ctrl, win720_round, extracted_num, username, orderNo, orderDate))
 
         self._show_result(body)
         return body
@@ -110,8 +111,8 @@ class Win720:
 
         return ret['orderNo'], ret['orderDate']
 
-    def _doConnPro(self, auth_ctrl: auth.AuthController, win720_round: str, extracted_num: str, orderNo: str, orderDate: str) -> str:
-        payload = "ROUND={}&FLAG=&BUY_KIND=01&BUY_NO={}&BUY_CNT=5&BUY_SET_TYPE=SA%2CSA%2CSA%2CSA%2CSA&BUY_TYPE=A%2CA%2CA%2CA%2CA%2C&CS_TYPE=01&orderNo={}&orderDate={}&TRANSACTION_ID=&WIN_DATE=&USER_ID={}&PAY_TYPE=&resultErrorCode=&resultErrorMsg=&resultOrderNo=&WORKING_FLAG=true&NUM_CHANGE_TYPE=&auto_process=N&set_type=SA&classnum=&selnum=&buytype=M&num1=&num2=&num3=&num4=&num5=&num6=&DSEC=34&CLOSE_DATE=&verifyYN=N&curdeposit=&curpay=5000&DROUND={}&DSEC=0&CLOSE_DATE=&verifyYN=N&lotto720_radio_group=on".format(win720_round,"".join([ "{}{}%2C".format(i,extracted_num) for i in range(1,6)])[:-3],orderNo, orderDate, "fantazm", win720_round)
+    def _doConnPro(self, auth_ctrl: auth.AuthController, win720_round: str, extracted_num: str, username: str, orderNo: str, orderDate: str) -> str:
+        payload = "ROUND={}&FLAG=&BUY_KIND=01&BUY_NO={}&BUY_CNT=5&BUY_SET_TYPE=SA%2CSA%2CSA%2CSA%2CSA&BUY_TYPE=A%2CA%2CA%2CA%2CA%2C&CS_TYPE=01&orderNo={}&orderDate={}&TRANSACTION_ID=&WIN_DATE=&USER_ID={}&PAY_TYPE=&resultErrorCode=&resultErrorMsg=&resultOrderNo=&WORKING_FLAG=true&NUM_CHANGE_TYPE=&auto_process=N&set_type=SA&classnum=&selnum=&buytype=M&num1=&num2=&num3=&num4=&num5=&num6=&DSEC=34&CLOSE_DATE=&verifyYN=N&curdeposit=&curpay=5000&DROUND={}&DSEC=0&CLOSE_DATE=&verifyYN=N&lotto720_radio_group=on".format(win720_round,"".join([ "{}{}%2C".format(i,extracted_num) for i in range(1,6)])[:-3],orderNo, orderDate, username, win720_round)
         headers = self._generate_req_headers(auth_ctrl)
         
         data = {

--- a/win720.py
+++ b/win720.py
@@ -1,7 +1,7 @@
 import json
 import datetime
-import requests
 import base64
+import requests
 
 from enum import Enum
 from bs4 import BeautifulSoup as BS
@@ -10,6 +10,8 @@ from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Hash import SHA256
 from Crypto.Random import get_random_bytes
+
+from HttpClient import HttpClientSingleton
 
 import auth
 
@@ -42,6 +44,9 @@ class Win720:
         "X-Requested-With": "XMLHttpRequest"
     }
 
+    def __init__(self):
+        self.http_client = HttpClientSingleton.get_instance()
+
     def buy_Win720(
         self, 
         auth_ctrl: auth.AuthController,
@@ -69,7 +74,7 @@ class Win720:
         return auth_ctrl.add_auth_cred_to_headers(self._REQ_HEADERS)
 
     def _get_round(self) -> str:
-        res = requests.get("https://www.dhlottery.co.kr/common.do?method=main")
+        res = self.http_client.get("https://www.dhlottery.co.kr/common.do?method=main")
         html = res.text
         soup = BS(
             html, "html5lib"
@@ -85,7 +90,7 @@ class Win720:
             "q": requests.utils.quote(self._encText(payload))
         }
 
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://el.dhlottery.co.kr/game/pension720/process/makeAutoNo.jsp", 
             headers=headers,
             data=data
@@ -101,7 +106,7 @@ class Win720:
             "q": requests.utils.quote(self._encText(payload))
         }
 
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://el.dhlottery.co.kr/game/pension720/process/makeOrderNo.jsp", 
             headers=headers,
             data=data
@@ -111,7 +116,7 @@ class Win720:
 
         return ret['orderNo'], ret['orderDate']
 
-    def _doConnPro(self, auth_ctrl: auth.AuthController, win720_round: str, extracted_num: str, username: str, orderNo: str, orderDate: str) -> str:
+    def _doConnPro(self, auth_ctrl: auth.AuthController, win720_round: str, extracted_num: str, orderNo: str, orderDate: str) -> str:
         payload = "ROUND={}&FLAG=&BUY_KIND=01&BUY_NO={}&BUY_CNT=5&BUY_SET_TYPE=SA%2CSA%2CSA%2CSA%2CSA&BUY_TYPE=A%2CA%2CA%2CA%2CA%2C&CS_TYPE=01&orderNo={}&orderDate={}&TRANSACTION_ID=&WIN_DATE=&USER_ID={}&PAY_TYPE=&resultErrorCode=&resultErrorMsg=&resultOrderNo=&WORKING_FLAG=true&NUM_CHANGE_TYPE=&auto_process=N&set_type=SA&classnum=&selnum=&buytype=M&num1=&num2=&num3=&num4=&num5=&num6=&DSEC=34&CLOSE_DATE=&verifyYN=N&curdeposit=&curpay=5000&DROUND={}&DSEC=0&CLOSE_DATE=&verifyYN=N&lotto720_radio_group=on".format(win720_round,"".join([ "{}{}%2C".format(i,extracted_num) for i in range(1,6)])[:-3],orderNo, orderDate, username, win720_round)
         headers = self._generate_req_headers(auth_ctrl)
         
@@ -119,7 +124,7 @@ class Win720:
             "q": requests.utils.quote(self._encText(payload))
         }
         
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://el.dhlottery.co.kr/game/pension720/process/connPro.jsp", 
             headers=headers,
             data=data
@@ -155,7 +160,7 @@ class Win720:
     def get_balance(self, auth_ctrl: auth.AuthController) -> str: 
         
         headers = self._generate_req_headers(auth_ctrl)
-        res = requests.post( 
+        res = self.http_client.post(
             url="https://dhlottery.co.kr/userSsl.do?method=myPage", 
             headers=headers
         )
@@ -165,7 +170,6 @@ class Win720:
             html, "html5lib"
         )
         balance = soup.find("p", class_="total_new").find('strong').text
-        print(balance, type(balance))
         return balance
 
     def check_winning(self, auth_ctrl: auth.AuthController) -> dict:
@@ -183,7 +187,7 @@ class Win720:
             "sortOrder": "DESC"
         }
 
-        res = requests.post(
+        res = self.http_client.post(
             "https://dhlottery.co.kr/myPage.do?method=lottoBuyList",
             headers=headers,
             data=data
@@ -222,8 +226,6 @@ class Win720:
 
     def _show_result(self, body: dict) -> None:
         assert type(body) == dict
-
-        print(f"{json.dumps(body)}")
 
         if body.get("loginYn") != "Y":
             return


### PR DESCRIPTION
싱글톤 requests session을 생성하여 한개의 연결로 requests를 처리할 수 있도록 했습니다 (webhook 제외)
또한, timeout과 post시에 allow redirect를 추가했습니다.
우선 10회 정도 테스트했고, connection refused 가 발생하지 않았습니다.