### PR TITLE
 Check winning numbers

### DIFF
--- a/lotto645.py
+++ b/lotto645.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import re
 
 from datetime import timedelta
 from enum import Enum

--- a/lotto645.py
+++ b/lotto645.py
@@ -1,5 +1,7 @@
 import datetime
 import json
+import re
+
 from datetime import timedelta
 from enum import Enum
 
@@ -176,7 +178,7 @@ class Lotto645:
             "nowPage": 1, 
             "searchStartDate": parameters["searchStartDate"],
             "searchEndDate": parameters["searchEndDate"],
-            "winGrade": 1,
+            "winGrade": 2,
             "lottoId": "LO40", 
             "sortOrder": "DESC"
         }
@@ -197,6 +199,38 @@ class Lotto645:
 
             winnings = soup.find("table", class_="tbl_data tbl_data_col").find_all("tbody")[0].find_all("td")
 
+            get_detail_info = winnings[3].find("a").get("href")
+
+            order_no, barcode, issue_no = get_detail_info.split("'")[1::2]
+            url = f"https://dhlottery.co.kr/myPage.do?method=lotto645Detail&orderNo={order_no}&barcode={barcode}&issueNo={issue_no}"
+
+            response = self.http_client.get(url)
+
+            soup = BS(response.text, "html5lib")
+
+            lotto_results = []
+
+            for li in soup.select("div.selected li"):
+                label = li.find("strong").find_all("span")[0].text.strip()
+                status = li.find("strong").find_all("span")[1].text.strip().replace("낙첨","0등")
+                nums = li.select("div.nums > span")
+
+                status = " ".join(status.split())
+
+                formatted_nums = []
+                for num in nums:
+                    ball = num.find("span", class_="ball_645")
+                    if ball:
+                        formatted_nums.append(f"✨{ball.text.strip()}")
+                    else:
+                        formatted_nums.append(num.text.strip())
+
+                lotto_results.append({
+                    "label": label,
+                    "status": status,
+                    "result": formatted_nums
+                })
+
             if len(winnings) == 1:
                 return result_data
 
@@ -204,7 +238,8 @@ class Lotto645:
                 "round": winnings[2].text.strip(),
                 "money": winnings[6].text.strip(),
                 "purchased_date": winnings[0].text.strip(),
-                "winning_date": winnings[7].text.strip()
+                "winning_date": winnings[7].text.strip(),
+                "lotto_details": lotto_results
             }
         except:
             pass

--- a/notification.py
+++ b/notification.py
@@ -39,7 +39,11 @@ class Notification:
         self._send_discord_webhook(webhook_url, message)
 
     def make_win720_number_message(self, win720_number: str) -> str:
-        return "\n".join(win720_number.split(","))
+        formatted_numbers = []
+        for number in win720_number.split(","):
+            formatted_number = f"{number[0]}조 " + " ".join(number[1:])
+            formatted_numbers.append(formatted_number)
+        return "\n".join(formatted_numbers)
 
     def send_lotto_winning_message(self, winning: dict, webhook_url: str) -> None: 
         assert type(winning) == dict
@@ -77,10 +81,7 @@ class Notification:
             else:
                 winning_message = f"로또 *{winning['round']}회* - 다음 기회에... 🫠"
 
-            if "discord" in webhook_url:
-                self._send_discord_webhook(webhook_url, f"```ini\n{formatted_results}```\n{winning_message}")
-            else:
-                self._send_discord_webhook(webhook_url, f"{winning_message}")
+            self._send_discord_webhook(webhook_url, f"```ini\n{formatted_results}```\n{winning_message}")
         except KeyError:
             return
 


### PR DESCRIPTION
#10
당첨 번호를 조회하고 메신저로 알려줍니다.

기존에는 낙첨시 아무런 알림이 없었지만, 이제는 번호가 몇개 맞았는지와 낙첨 소식을 알려줍니다.
- 당첨되었을때는 당첨메세지로 변경
- 색상 하이라이트는 디스코드에서만 동작함
- 간격을 맞추기 위해 임의로 낙첨을 0등으로 수정했습니다

연금복권 구매시 전송되는 알림 메세지 포맷 수정
